### PR TITLE
Wip level and stacktrace output

### DIFF
--- a/src/clj_journal/timbre.clj
+++ b/src/clj_journal/timbre.clj
@@ -23,7 +23,7 @@
   ([err]
    (stacktrace err nil))
   ([err _opts]
-   (str err)))
+   (taoensso.timbre/stacktrace err)))
 
 (defn journal-output-fn
   "journal (fn [data]) -> string output fn.

--- a/src/clj_journal/timbre.clj
+++ b/src/clj_journal/timbre.clj
@@ -1,5 +1,6 @@
 (ns clj-journal.timbre
-  (:require [clj-journal.log :refer [jsend]]))
+  (:require [clojure.string :as str]
+            [clj-journal.log :refer [jsend]]))
 
 (def timbre->syslog-map
   "Map timbre log levels to syslog levels"
@@ -38,8 +39,9 @@
   ([data] (journal-output-fn nil data))
   ([opts data] ; For partials
    (let [{:keys [show-fields? no-stacktrace? stacktrace-fonts]} opts
-         {:keys [?err vargs msg_ ?ns-str ?file ?line]}          data]
-     (str "[" (or ?ns-str ?file "?") ":" (or ?line "?") "] - "
+         {:keys [level ?err vargs msg_ ?ns-str ?file ?line]}          data]
+     (str (str/upper-case (name level)) " "
+          "[" (or ?ns-str ?file "?") ":" (or ?line "?") "] - "
           (if show-fields?
             (force msg_)
             (clojure.string/join " " (filter (comp not map?) vargs)))


### PR DESCRIPTION
Only briefly tested, but perhaps useful.

* `(log/error (Exception. "hi"))` will yield a stacktrace just like the standard timbre appender.
* Log event messages now include the log level which is pretty standard I guess.