### PR TITLE
Wip format string

### DIFF
--- a/src/clj_journal/log.clj
+++ b/src/clj_journal/log.clj
@@ -4,20 +4,8 @@
             [clj-journal.util :refer :all]
             [clojure.string]))
 
-(def ^:dynamic *strict*
-  "Whether we should raise an exception on `%n` values in strings, or if we
-  should silently replace it with `%_n` to avoid the \"%n in writable segment
-  detected\" C printf error from killing the JVM."
-  false)
-
-(defn sanitize-format-string
-  [s]
-  (let [s* (clojure.string/replace s #"%n" "%_n")]
-    (when (and (not= s s*)
-               *strict*)
-      (throw (ex-info "Invalid format string in log message"
-                      {:string s})))
-    s*))
+(defn sanitize-format-string [s]
+  (clojure.string/replace s #"%" "%%"))
 
 (defn jprint
   "Submit simple plain text messages to the journal log.

--- a/src/clj_journal/timbre.clj
+++ b/src/clj_journal/timbre.clj
@@ -23,7 +23,7 @@
   ([err]
    (stacktrace err nil))
   ([err _opts]
-   (str err)))
+   (taoensso.timbre/stacktrace err)))
 
 (defn journal-output-fn
   "journal (fn [data]) -> string output fn.

--- a/src/clj_journal/timbre.clj
+++ b/src/clj_journal/timbre.clj
@@ -1,5 +1,6 @@
 (ns clj-journal.timbre
-  (:require [clj-journal.log :refer [jsend]]))
+  (:require [clojure.string :as str]
+            [clj-journal.log :refer [jsend]]))
 
 (def timbre->syslog-map
   "Map timbre log levels to syslog levels"
@@ -38,8 +39,9 @@
   ([data] (journal-output-fn nil data))
   ([opts data] ; For partials
    (let [{:keys [show-fields? no-stacktrace? stacktrace-fonts]} opts
-         {:keys [?err vargs msg_ ?ns-str ?file ?line]}          data]
-     (str "[" (or ?ns-str ?file "?") ":" (or ?line "?") "] - "
+         {:keys [level ?err vargs msg_ ?ns-str ?file ?line]}          data]
+     (str (str/upper-case (name level)) " "
+          "[" (or ?ns-str ?file "?") ":" (or ?line "?") "] - "
           (if show-fields?
             (force msg_)
             (clojure.string/join " " (filter (comp not map?) vargs)))


### PR DESCRIPTION
All instances of % should be escaped to %% ref http://man7.org/linux/man-pages/man3/printf.3.html which is mentioned here https://www.freedesktop.org/software/systemd/man/sd_journal_print.html

..only briefly tested, but now outputting a single % works and %n doesn't kill the JVM.