### PR TITLE
No longer expose the format string capability of the underlying library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.3.0] - 2021-12-11
+### Removed
+- No longer expose the format string capability of the underlying library as
+  using it incorrectly or unintentionally can lead to JVM crashes or unintended
+  data being logged.
+
 ## [0.2.5-1] - 2019-05-22
 ### Fixed
 - Fixed issue when log message contains `%n`, which would cause `printf` to

--- a/README.org
+++ b/README.org
@@ -13,7 +13,7 @@ Includes a log appender for timbre.
 ** Installation
 
 #+BEGIN_SRC clojure
-  [runejuhl/clj-journal "0.2.5-1"]
+  [runejuhl/clj-journal "0.3.0"]
 #+END_SRC
 
 ** Usage
@@ -50,19 +50,3 @@ of converting a keyword/string reprentation of the log level to an integer:
                                       :leet  1337
                                       :weird {:blegh "lollo"}})
 #+END_SRC
-
-** Bugs/issues
-
-*** Logging ~%n~
-
-Previous to version ~v0.2.5-1~ the JVM would crash if trying to log a string
-containing ~%n~. For some reason this would also happen if the ~n~ was a
-newline, e.g. logging the string ~omg %\n~.
-
-In order to combat this we've introduced the dynamic variable
-~clj-journal.log/*strict*~, which defaults to ~false~. When the value is non-nil
-~clj-journal~ will throw an exception if it encounters ~%n~; otherwise it'll
-silently replace ~%n~ with ~%_n~.
-
-It is, of course, less than optimal for a logging framework to silently change
-the log messages, so /caveat emptor/. Oh, and help wanted!

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject runejuhl/clj-journal "0.2.5-1"
+(defproject runejuhl/clj-journal "0.3.0"
   :description "Structured logging to systemd journal using native systemd libraries and JNA
 (Java Native Access)"
   :url "https://github.com/runejuhl/clj-journal"

--- a/src/clj_journal/errno.clj
+++ b/src/clj_journal/errno.clj
@@ -1,12 +1,12 @@
 (ns clj-journal.errno
-  (:import [com.sun.jna Library Native Platform]))
+  (:import [com.sun.jna Function]))
 
 (def ^com.sun.jna.Function strerror
-  (com.sun.jna.Function/getFunction "c" "strerror"))
+  (Function/getFunction "c" "strerror"))
 
 (defn errno->string
   "Convert ISO C integer `errno` into a string describing the error. Returns nil
   if `errno` is 0."
   [errno]
-  (if-not (zero? errno)
+  (when-not (zero? errno)
     (.invoke strerror String (to-array [errno]))))

--- a/src/clj_journal/log.clj
+++ b/src/clj_journal/log.clj
@@ -4,29 +4,14 @@
             [clj-journal.util :refer :all]
             [clojure.string]))
 
-(def ^:dynamic *strict*
-  "Whether we should raise an exception on `%n` values in strings, or if we
-  should silently replace it with `%_n` to avoid the \"%n in writable segment
-  detected\" C printf error from killing the JVM."
-  false)
-
-(defn sanitize-format-string
-  [s]
-  (let [s* (clojure.string/replace s #"%n" "%_n")]
-    (when (and (not= s s*)
-               *strict*)
-      (throw (ex-info "Invalid format string in log message"
-                      {:string s})))
-    s*))
-
 (defn jprint
   "Submit simple plain text messages to the journal log.
 
   Returns a partial function if only `log-level` is given."
   ([log-level]
    (partial jprint log-level))
-  ([log-level fmt & args]
-   (->> (flatten [(level->syslog log-level) (sanitize-format-string fmt) args])
+  ([log-level msg]
+   (->> [(level->syslog log-level) "%s" msg]
         (to-array)
         (.invoke sd_journal_print Integer)
         (errno->string))))
@@ -41,7 +26,7 @@
   ([log-level msg & args]
    {:pre [(-> args count even?)]}
    (->> args
-        (concat [:message   (sanitize-format-string msg)
+        (concat [:message msg
                  :priority (level->syslog log-level)])
         (apply args->journal-fields)
         ;; The varargs for the sd_journal functions needs to end with a null

--- a/src/clj_journal/systemd.clj
+++ b/src/clj_journal/systemd.clj
@@ -1,11 +1,11 @@
 (ns clj-journal.systemd
-  (:import [com.sun.jna Library Native Platform]))
+  (:import [com.sun.jna Function]))
 
 (try
   (def ^com.sun.jna.Function sd_journal_print
-    (com.sun.jna.Function/getFunction "systemd" "sd_journal_print"))
+    (Function/getFunction "systemd" "sd_journal_print"))
   (def ^com.sun.jna.Function sd_journal_send
-    (com.sun.jna.Function/getFunction "systemd" "sd_journal_send"))
+    (Function/getFunction "systemd" "sd_journal_send"))
   (catch java.lang.UnsatisfiedLinkError ex
     (ex-info "Unable to open systemd library; is it installed?"
              {:cause :missing-library

--- a/src/clj_journal/timbre.clj
+++ b/src/clj_journal/timbre.clj
@@ -1,5 +1,6 @@
 (ns clj-journal.timbre
-  (:require [clj-journal.log :refer [jsend]]))
+  (:require [clojure.string]
+            [clj-journal.log :refer [jsend]]))
 
 (def timbre->syslog-map
   "Map timbre log levels to syslog levels"
@@ -10,7 +11,7 @@
    :error  3                       ;err
    :report 1                       ;alert
    :fatal  0                       ;emerg
-})
+   })
 
 (defn ^:dynamic timbre->syslog
   "Convert Timbre log level into the syslog equivalent.
@@ -37,7 +38,7 @@
   duplicate keys in maps passed in `vargs`."
   ([data] (journal-output-fn nil data))
   ([opts data] ; For partials
-   (let [{:keys [show-fields? no-stacktrace? stacktrace-fonts]} opts
+   (let [{:keys [show-fields? no-stacktrace?]} opts
          {:keys [?err vargs msg_ ?ns-str ?file ?line]}          data]
      (str "[" (or ?ns-str ?file "?") ":" (or ?line "?") "] - "
           (if show-fields?
@@ -55,7 +56,7 @@
   Any maps passed to a timbre logger will be sent to journal as structured data.
   Any complex data structures in values will be serialized as EDN."
   ([]
-   (journal-appender (fn [{:keys [?file ?line ?ns-str] :as data}]
+   (journal-appender (fn [{:keys [?file ?line ?ns-str] :as _data}]
                        {"CODE_FILE" ?file
                         "CODE_LINE" ?line
                         "CODE_NS"   ?ns-str})))
@@ -66,7 +67,7 @@
     :rate-limit nil
     :output-fn  journal-output-fn
     :fn
-    (fn [{:keys [instant level output_ vargs]
+    (fn [{:keys [level output_ vargs]
           :as   data}]
       (let [default-fields (default-fields-fn data)
             log-maps       (filter map? vargs)

--- a/src/clj_journal/util.clj
+++ b/src/clj_journal/util.clj
@@ -1,4 +1,5 @@
-(ns clj-journal.util)
+(ns clj-journal.util
+  (:require [clojure.string]))
 
 (def ^clojure.lang.PersistentList log-levels
   "Symbolic log levels. Based on `man syslog.2`:
@@ -38,7 +39,7 @@
   (stringify [s] s)
   clojure.lang.Keyword
   (stringify [k] (str
-                  (if-let [n (namespace k)]
+                  (when-let [n (namespace k)]
                     (str n "_"))
                   (name k)))
   Object

--- a/src/clj_journal/util.clj
+++ b/src/clj_journal/util.clj
@@ -71,7 +71,7 @@
   (->> args
        (partition 2)
        (filter (comp not nil? second))
-       (map
+       (mapcat
         (fn [[k v]]
-          (str (to-field-name k) "=" v)))
+          ["%s" (str (to-field-name k) "=" v)]))
        (into [])))

--- a/src/clj_journal/util.clj
+++ b/src/clj_journal/util.clj
@@ -56,7 +56,7 @@
       (clojure.string/upper-case)
       ;; make sure we don't have invalid characters in field names, as fields
       ;; will be silently dropped
-      (clojure.string/replace #"[^A-Z_]" "_")
+      (clojure.string/replace #"[^A-Z0-9_]" "_")
       (#(if (re-find #"^[A-Z]" %)
           %
           (str "X_" %)))))

--- a/test/clj_journal/log_test.clj
+++ b/test/clj_journal/log_test.clj
@@ -1,6 +1,7 @@
 (ns clj-journal.log-test
-  (:require [clj-journal.log :refer :all]
-            [clojure.test :refer :all]))
+  (:require [clj-journal.log :refer [jprint jsend]]
+            [clj-journal.util]
+            [clojure.test :refer [deftest is testing]]))
 
 (deftest logging
   (testing "print"

--- a/test/clj_journal/log_test.clj
+++ b/test/clj_journal/log_test.clj
@@ -5,9 +5,9 @@
 
 (deftest logging
   (testing "print"
-    (is (nil? (jprint :err "test! %s" "a string!")))
-    (is (nil? (jprint :err "testing more: %x" 3735928559)))
-    (is (nil? (jprint :err "testing more: %n" 3735928559)))
+    (is (nil? (jprint :err "test! a string!")))
+    (is (nil? (jprint :err "testing more: %x")))
+    (is (nil? (jprint :err "testing more: %n")))
 
     (is (nil?
          (binding [clj-journal.util/level->syslog (fn [_] 1)]

--- a/test/clj_journal/test/util.clj
+++ b/test/clj_journal/test/util.clj
@@ -5,8 +5,8 @@
 (defn get-journal-entry
   "Get a single journal entry with a particular ID."
   [id]
-  (let [{:keys [out exit] :as entry}
+  (let [{:keys [out exit] :as _entry}
         (sh/sh "journalctl" "-n1"  "--output=json" (str "CLJ_JOURNAL_IDENTIFIER=" id))]
-    (if (and (zero? exit) (not (empty? out)))
+    (when (and (zero? exit) (seq out))
       (json/read-str out
-        :key-fn keyword))))
+                     :key-fn keyword))))

--- a/test/clj_journal/timbre_test.clj
+++ b/test/clj_journal/timbre_test.clj
@@ -1,7 +1,7 @@
 (ns clj-journal.timbre-test
-  (:require [clj-journal.timbre :refer :all]
+  (:require [clj-journal.timbre :refer [journal-appender]]
             [clj-journal.test.util :refer [get-journal-entry]]
-            [clojure.test :refer :all]
+            [clojure.test :refer [deftest is use-fixtures]]
             [taoensso.timbre :as timbre]))
 
 (defmacro log

--- a/test/clj_journal/util_test.clj
+++ b/test/clj_journal/util_test.clj
@@ -4,7 +4,7 @@
 
 (deftest utility
   (is (= (args->journal-fields "some" 12 "value" "message")
-         ["SOME=12" "VALUE=message"])
+         ["%s" "SOME=12" "%s" "VALUE=message"])
       "Should return a vector of strings")
 
   (is (thrown? AssertionError (args->journal-fields "some" 12 "value"))


### PR DESCRIPTION
Using it incorrectly or unintentionally can lead to JVM crashes or unintended
data being logged.
One example is a format string which contains %n to which a workaround was
applied in 0.2.5-1. Other occurrences of % can however cause problems too as they
will cause sd_journal_print/send to look for args which might not actually have
been supplied. For example (jprint :info "%x") will either log whatever value
is in the place a third arg would've been or crash the JVM if that place wasn't
allocated.

As this is a breaking change I also took the liberty to bump the version to 0.3.0

I'm aware that https://github.com/runejuhl/clj-journal/pull/6 has the same aim however I think that my approach is cleaner.